### PR TITLE
Improve Home first-run memory state

### DIFF
--- a/src/modules/home/home-screen.tsx
+++ b/src/modules/home/home-screen.tsx
@@ -38,14 +38,36 @@ type EntrySection = {
   data: EntryListItem[];
 };
 
+type HomeScreenMemoryState = {
+  entries: EntryListItem[];
+  todaySteps: number | null;
+  stepPermission: StepPermissionStatus;
+  stepSource: StepSource;
+  hasLoadedOnce: boolean;
+};
+
+const initialMemoryState: HomeScreenMemoryState = {
+  entries: [],
+  todaySteps: null,
+  stepPermission: "undetermined",
+  stepSource: "apple-health",
+  hasLoadedOnce: false,
+};
+
+let homeScreenMemoryState: HomeScreenMemoryState = initialMemoryState;
+
 export default function HomeScreen() {
   const db = useSQLiteContext();
   const router = useRouter();
-  const [entries, setEntries] = useState<EntryListItem[]>([]);
-  const [todaySteps, setTodaySteps] = useState<number | null>(null);
-  const [stepPermission, setStepPermission] =
-    useState<StepPermissionStatus>("undetermined");
-  const [stepSource, setStepSource] = useState<StepSource>("apple-health");
+  const [entries, setEntries] = useState<EntryListItem[]>(homeScreenMemoryState.entries);
+  const [todaySteps, setTodaySteps] = useState<number | null>(
+    homeScreenMemoryState.todaySteps,
+  );
+  const [stepPermission, setStepPermission] = useState<StepPermissionStatus>(
+    homeScreenMemoryState.stepPermission,
+  );
+  const [stepSource, setStepSource] = useState<StepSource>(homeScreenMemoryState.stepSource);
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(homeScreenMemoryState.hasLoadedOnce);
   const openSwipeableRef = useRef<EntrySwipeRowHandle | null>(null);
 
   const loadHome = useCallback(async () => {
@@ -59,7 +81,16 @@ export default function HomeScreen() {
       setTodaySteps(stepSnapshot.totalSteps);
       setStepPermission(stepSnapshot.permission);
       setStepSource(stepSnapshot.source);
+      setHasLoadedOnce(true);
     });
+
+    homeScreenMemoryState = {
+      entries: nextEntries,
+      todaySteps: stepSnapshot.totalSteps,
+      stepPermission: stepSnapshot.permission,
+      stepSource: stepSnapshot.source,
+      hasLoadedOnce: true,
+    };
 
     if (stepSnapshot.permission === "granted") {
       void upsertDailySteps(db, makeDailyStepsRecord(stepSnapshot.totalSteps));
@@ -167,7 +198,13 @@ export default function HomeScreen() {
           </Pressable>
         </View>
 
-        {sections.length === 0 ? (
+        {!hasLoadedOnce ? (
+          <View style={styles.listWrap}>
+            <PaperRow>
+              <Text style={styles.emptyText}>Loading your notebook...</Text>
+            </PaperRow>
+          </View>
+        ) : sections.length === 0 ? (
           <View style={styles.listWrap}>
             <PaperRow>
               <Text style={styles.emptyText}>No entry yet.</Text>


### PR DESCRIPTION
### Motivation
- Prevent the Home screen from flashing a misleading empty state before the initial data fetch completes by tracking first-load status.
- Preserve recently-fetched Home data (entries, step totals, permission and source) across quick in-session remounts so the screen can bootstrap immediately from cached state.

### Description
- Add a `HomeScreenMemoryState` type and a module-level `homeScreenMemoryState` snapshot to hold `entries`, `todaySteps`, `stepPermission`, `stepSource`, and `hasLoadedOnce`.
- Seed the Home screen `useState` hooks from `homeScreenMemoryState` so remounted Home starts with the cached values instead of empty defaults.
- Update `loadHome` to set `hasLoadedOnce`, refresh the module-level snapshot after a successful fetch, and continue to persist step totals when permission is granted via `upsertDailySteps`.
- Replace the immediate empty-state UI with a first-run placeholder that shows `Loading your notebook...` until the first successful load completes, then fall back to the existing `No entry yet.` message when appropriate.

### Testing
- Ran `npm run typecheck` and it completed successfully (TypeScript checks passed). (`npm run typecheck` ✅)
- Ran `npm run ci:check` but it failed in this environment due to `npx expo-doctor` not being downloadable from the npm registry (HTTP 403), so full CI checks could not complete here. (`npm run ci:check` ⚠️)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6e4ec9804832ea8554527854774ab)